### PR TITLE
Add link on Freenode webchat (http://trac.buildbot.net/ticket/2679)

### DIFF
--- a/src/contact.jade
+++ b/src/contact.jade
@@ -18,7 +18,7 @@ block content
                 As an open source project, most communication about Buildbot is done in the open:
 
                  * The [buildbot-devel mailing list](https://lists.sourceforge.net/lists/listinfo/buildbot-devel)
-                 * The #buildbot IRC channel on Freenode
+                 * The [#buildbot](http://webchat.freenode.net/?channels=%23buildbot) IRC channel on Freenode
                  * The [project organization](http://github.com/buildbot) on Github
                  * The Buildbot [issue tracker](http://trac.buildbot.net)
 


### PR DESCRIPTION
http://webchat.freenode.net/?channels=%23buildbot

It also possible to include such chat to site via iframe and to configure
default username, color scheme, etc.
