### PR TITLE
Align the PyPI buttons properly

### DIFF
--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -171,6 +171,9 @@ header {
   *display: inline;
   *zoom: 1;
 }
+.bs-docs-social-buttons img {
+  vertical-align: baseline;
+}
 .hero-unit.light {
   padding: 40px;
   font-size: 16px;

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -150,9 +150,6 @@ header {
   border-top: 1px solid rgba(245, 245, 245, 0.25);
   border-bottom: 1px solid rgba(221, 221, 221, 0.25);
 }
-.bs-docs-social ul.bs-docs-social-buttons li {
-  padding: 5px 0px;
-}
 .authors-social-buttons {
   vertical-align: middle;
   display: inline-block;


### PR DESCRIPTION
Without this patch, the default img vertical alignment is "middle" which doesn't match the rest of the social buttons.