### PR TITLE
Mention that python2.7 is dropped only for master

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -21,7 +21,7 @@ block content
   .alert.alert-danger.text-center
     h4
       span.glyphicon.glyphicon-exclamation-sign
-      | Buildbot is dropping support for Python 2.7. Users are encouraged to migrate to Python 3 as soon as possible.
+      | Buildbot is dropping support for Python 2.7 for the master. Users are encouraged to migrate to Python 3 as soon as possible.
     h4
       a(href="https://github.com/buildbot/buildbot/issues/4439") More info
   .container.subpage


### PR DESCRIPTION
Some users may freak out that they must also modify the slaves.