### PR TITLE
Update the list of projects using Buildbot

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -128,7 +128,7 @@ block content
         They are not well-suited to more complex cases, such as mixed-language applications or complex release tasks, where those assumptions are violated.
 
         Buildbot's design allows your installation to grow with your requirements, beginning with simple processes and growing to meet your unique needs.
-        This flexibility has led to its use in a number of high-profile open-source projects, including [Chromium, WebKit, Firefox, Python, and Twisted](https://github.com/buildbot/buildbot/wiki/SuccessStories).
+        This flexibility has led to its use in a number of high-profile open-source projects, including [WebKit, Python, and Twisted](https://github.com/buildbot/buildbot/wiki/SuccessStories).
 
     .col-xs-3
       img(src="img/nut.svg", style="width:90%")


### PR DESCRIPTION
Chromium and Firefox have moved to their own homegrown CI alternatives.