### PR TITLE
Remove obsolete warning banner

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -17,12 +17,6 @@ block content
           li: +codecov-badge
           li: +doc-badge
           li: +twitter
-  .alert.alert-danger.text-center
-    h4
-      span.glyphicon.glyphicon-exclamation-sign
-      | Buildbot is dropping support for Python 2.7 for the master. Users are encouraged to migrate to Python 3 as soon as possible.
-    h4
-      a(href="https://github.com/buildbot/buildbot/issues/4439") More info
   .container.subpage
     +carousel('main', 3)
       +carousel-panel(0)


### PR DESCRIPTION
This PR removes obsolete warning banner as Buildbot has dropped supporting Python 2.7 a long time ago and the banner is no longer needed. Fixes  issue: Drop "Buildbot is dropping 2.7 support from master" banner #74 
