### PR TITLE
circleci: Upgrade to next-generation CircleCI build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: cimg/node:18.16.1
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Legacy images which we currently use have been deprecated in 2020 already:
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034.

Currently the builds fail due to github.com host keys being not recognized. These were changed some time ago so the error is expected.