### PR TITLE
Fix documentation links under 'Get Started'

### DIFF
--- a/src/_include/layout.jade
+++ b/src/_include/layout.jade
@@ -30,8 +30,8 @@ html.no-js(xmlns:ng='http://angularjs.org', xmlns:app='ignored')
             +nav_item('https://github.com/buildbot/buildbot/wiki/Press') Press
             +nav_item('https://buildbot.buildbot.net') Metabuildbot: Buildbot's Buildbot
         +nav_item_dropdown("#")(label="Get Started")
-            +nav_item('http://buildbot.net/buildbot/docs/current/tutorial/') Follow the Tutorial
-            +nav_item('http://buildbot.net/buildbot/docs/current/index.html') Read the Docs
+            +nav_item('https://docs.buildbot.net/current/tutorial/index.html') Follow the Tutorial
+            +nav_item('https://docs.buildbot.net/current/') Read the Docs
             +nav_item('http://docs.buildbot.net/current/manual/installation/installation.html') Download and Install
             li.divider
         +nav_item_dropdown("#")(label="Get Involved")


### PR DESCRIPTION
Two documentation links under 'Get Started' were pointing to 404 errors.

Guessing the documentation was moved at some point?
