### PR TITLE
Fixed bug that prevented 'live reload' to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "./watch.sh",
+    "dev": "sh ./watch.sh",
     "compile": "harp src dist"
   },
   "devDependencies": {

--- a/src/_include/layout.jade
+++ b/src/_include/layout.jade
@@ -40,6 +40,5 @@ html.no-js(xmlns:ng='http://angularjs.org', xmlns:app='ignored')
             li.divider
             +nav_item('http://github.com/buildbot/buildbot') Get the Source
             +nav_item('http://docs.buildbot.net/current/developer/tests.html#quick-start') Get Started Hacking
-            +nav_item('http://github.com/buildbot/buildbot/issues') File or Fix a Bug
-        +nav_item("https://medium.com/buildbot") Blog
+            +nav_item('http://github.com/buildbot/buildbot/issues') File or Fix a Bug        
     block content

--- a/watch.sh
+++ b/watch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Kill parallel tasks together.
 # http://unix.stackexchange.com/a/107405
@@ -10,7 +10,7 @@ killgroup () {
   kill 0
 }
 
-dir=$(dirname "${BASH_SOURCE[0]}")
+dir="$(dirname "${0}")"
 
 $dir/node_modules/harp/bin/harp src &
 node $dir/node_modules/livereloadx/bin/livereloadx.js --include '**/*.{jade,less}' &


### PR DESCRIPTION
- Fixed string substitution on 'watch.sh'
- Changed call for 'watch.sh' in 'package.json'
- Change script interpreter to 'sh'